### PR TITLE
ec-recover

### DIFF
--- a/src/ecr.sw
+++ b/src/ecr.sw
@@ -19,10 +19,10 @@ pub fn ec_recover(signature: B512, msg_hash: b256) -> B512 {
 
     // a `B512`'s 2 internal values are stored in contiguous memory. This asm block takes a pointer to the initial value (public_key.hi) and should retrieve the lo value from memory and return it to be stored in public_key.lo.
     public_key.lo = asm(buffer, hi_ptr: public_key.hi, lo_ptr) {
-        move buffer sp;
-        cfei i32;
         move hi_ptr sp;
         cfei i64;
+        move buffer sp;
+        cfei i32;
         addi lo_ptr hi_ptr i32; // set lo_ptr equal to hi_ptr + 32 bytes
         move lo_ptr sp;
         cfei i32;

--- a/src/ecr.sw
+++ b/src/ecr.sw
@@ -5,8 +5,6 @@ use ::address::Address;
 
 /// Recover the address derived from the private key used to sign a message
 pub fn ec_recover_address(signature: B512, msg_hash: b256) -> Address {
-    // ECR: "The 64-byte public key (x, y) recovered from 64-byte signature starting at $rB on 32-byte message hash starting at $rC"
-    // s256: The sha-256 hash of $rC bytes starting at $rB.
     let address = asm(pub_key_buffer, sig_ptr: signature.hi, hash: msg_hash, addr_buffer, sixty_four: 64) {
         move pub_key_buffer sp; // mv sp to pub_key result buffer.
         cfei i64;

--- a/src/ecr.sw
+++ b/src/ecr.sw
@@ -8,7 +8,7 @@ use ::chain::assert;
 pub fn ec_recover(signature: B512, msg_hash: b256) -> B512 {
     let public_key = ~B512::new();
 
-    public_key.hi = asm(buffer, hi: signature.hi, hash: msg_hash) {
+    let hi = asm(buffer, hi: signature.hi, hash: msg_hash) {
         move buffer sp; // Result buffer.
         cfei i32;
         ecr buffer hi hash;
@@ -23,6 +23,7 @@ pub fn ec_recover(signature: B512, msg_hash: b256) -> B512 {
         mcpi buffer lo_ptr i32; // copy 32 bytes starting at lo_ptr into buffer
         buffer: b256
     };
+    public_key.hi = hi;
     public_key
 }
 

--- a/src/ecr.sw
+++ b/src/ecr.sw
@@ -1,0 +1,30 @@
+library ecr;
+
+use ::b512::B512;
+use ::address::Address;
+
+/// Recover the address derived from the private key used to sign a message
+pub fn ec_recover(signature: B512, msg_hash: b256) -> Address {
+
+    // we know that the B512 type's inner values are contiguous in memory.
+    // the ERC OpCode descriptions states:
+    // "The 64-byte public key (x, y) recovered from 64-byte signature starting at $rB on 32-byte message hash starting at $rC"
+    // Store the first 32 bytes of the public key in pub_key_initial_bytes:
+    // @todo optimize. roll these 2 asm blocks into 1 and remove local variables.
+    let pub_key_initial_bytes = asm(buffer, hi: signature.hi, hash: msg_hash) {
+        move buffer sp; // Result buffer.
+        cfei i32;
+        ecr buffer hi hash;
+        buffer: b256
+    };
+
+    // hash 64 bytes starting at `first` (start of 64-byte public key)
+    let address = asm(buffer, first: pub_key_initial_bytes , r3: 64) {
+        move buffer sp; // Result buffer.
+        cfei i32;
+        s256 buffer first r3; // hash 64 bytes to the buffer
+        buffer: b256
+    };
+
+    ~Address::from(address)
+}

--- a/src/ecr.sw
+++ b/src/ecr.sw
@@ -2,11 +2,41 @@ library ecr;
 
 use ::b512::B512;
 use ::address::Address;
+use ::chain::assert;
 
-// @todo expose both a recovered address && a recovered public key for consumption
+/// Recover the public key derived from the private key used to sign a message
+pub fn ec_recover(signature: B512, msg_hash: b256) -> B512 {
+    let public_key = ~B512::new();
+
+    public_key.hi = asm(buffer, hi: signature.hi, hash: msg_hash) {
+        move buffer sp; // Result buffer.
+        cfei i32;
+        ecr buffer hi hash;
+        buffer: b256
+    };
+    // @note temp
+    assert(public_key.hi == 0x1d152307c6b72b0ed0418b0e70cd80e7f5295b8d86f5722d3f5213fbd2394f36);
+
+    // a `B512`'s 2 internal values are stored in contiguous memory. This asm block takes a pointer to the initial value (public_key.hi) and should retrieve the lo value from memory and return it to be stored in public_key.lo.
+    public_key.lo = asm(buffer, hi_ptr: public_key.hi, lo_ptr) {
+        move buffer sp;
+        cfei i32;
+        move hi_ptr sp;
+        cfei i64;
+        addi lo_ptr hi_ptr i32; // set lo_ptr equal to hi_ptr + 32 bytes
+        move lo_ptr sp;
+        cfei i32;
+        mcpi buffer lo_ptr i32; // copy 32 bytes starting at lo_ptr into buffer
+        buffer: b256
+    };
+    // @note temp
+    assert(public_key.lo == 0xb7ce9c3e45905178455900b44abb308f3ef480481a4b2ee3f70aca157fde396a);
+
+    public_key
+}
 
 /// Recover the address derived from the private key used to sign a message
-pub fn ec_recover(signature: B512, msg_hash: b256) -> Address {
+pub fn ec_recover_address(signature: B512, msg_hash: b256) -> Address {
 
     // ECR: "The 64-byte public key (x, y) recovered from 64-byte signature starting at $rB on 32-byte message hash starting at $rC"
     // s256: The sha-256 hash of $rC bytes starting at $rB.
@@ -21,24 +51,4 @@ pub fn ec_recover(signature: B512, msg_hash: b256) -> Address {
     };
 
     ~Address::from(address)
-}
-
-/// Recover the public key derived from the private key used to sign a message
-pub fn recover_pubkey(signature: B512, msg_hash: b256) -> B512 {
-    let pub_key_hi = asm(buffer, hi: signature.hi, hash: msg_hash) {
-        move buffer sp; // Result buffer.
-        cfei i32;
-        ecr buffer hi hash;
-        buffer: b256
-    };
-
-    let pub_key_lo = asm(buffer, hi_ptr: pub_key_hi, lo) {
-        move buffer sp;
-        cfei i32;
-        addi lo hi_ptr i32;
-        mcpi buffer lo i32;
-        buffer: b256
-    };
-
-    ~B512::from(pub_key_hi, pub_key_lo)
 }

--- a/src/ecr.sw
+++ b/src/ecr.sw
@@ -3,28 +3,42 @@ library ecr;
 use ::b512::B512;
 use ::address::Address;
 
+// @todo expose both a recovered address && a recovered public key for consumption
+
 /// Recover the address derived from the private key used to sign a message
 pub fn ec_recover(signature: B512, msg_hash: b256) -> Address {
 
-    // we know that the B512 type's inner values are contiguous in memory.
-    // the ERC OpCode descriptions states:
-    // "The 64-byte public key (x, y) recovered from 64-byte signature starting at $rB on 32-byte message hash starting at $rC"
-    // Store the first 32 bytes of the public key in pub_key_initial_bytes:
-    // @todo optimize. roll these 2 asm blocks into 1 and remove local variables.
-    let pub_key_initial_bytes = asm(buffer, hi: signature.hi, hash: msg_hash) {
+    // ECR: "The 64-byte public key (x, y) recovered from 64-byte signature starting at $rB on 32-byte message hash starting at $rC"
+    // @todo switch to using s256 opcode for hashing!
+    let address = asm(pub_key_buffer, sig_ptr: signature.hi, hash: msg_hash, addr_buffer, r3: 64) {
+        move pub_key_buffer sp; // pub_key result buffer.
+        cfei i64;
+        ecr pub_key_buffer sig_ptr hash; // recover public_key from sig & hash
+        move addr_buffer sp; // addr result buffer.
+        cfei i32;
+        k256 addr_buffer pub_key_buffer r3; // hash 64 bytes to the addr_buffer
+        addr_buffer: b256
+    };
+
+    ~Address::from(address)
+}
+
+/// Recover the public key derived from the private key used to sign a message
+pub fn recover_pubkey(signature: B512, msg_hash: b256) -> B512 {
+    let pub_key_hi = asm(buffer, hi: signature.hi, hash: msg_hash) {
         move buffer sp; // Result buffer.
         cfei i32;
         ecr buffer hi hash;
         buffer: b256
     };
 
-    // hash 64 bytes starting at `first` (start of 64-byte public key)
-    let address = asm(buffer, first: pub_key_initial_bytes , r3: 64) {
-        move buffer sp; // Result buffer.
+    let pub_key_lo = asm(buffer, hi_ptr: pub_key_hi, lo) {
+        move buffer sp;
         cfei i32;
-        s256 buffer first r3; // hash 64 bytes to the buffer
+        addi lo hi_ptr i32;
+        mcpi buffer lo i32;
         buffer: b256
     };
 
-    ~Address::from(address)
+    ~B512::from(pub_key_hi, pub_key_lo)
 }

--- a/src/ecr.sw
+++ b/src/ecr.sw
@@ -9,14 +9,14 @@ use ::address::Address;
 pub fn ec_recover(signature: B512, msg_hash: b256) -> Address {
 
     // ECR: "The 64-byte public key (x, y) recovered from 64-byte signature starting at $rB on 32-byte message hash starting at $rC"
-    // @todo switch to using s256 opcode for hashing!
-    let address = asm(pub_key_buffer, sig_ptr: signature.hi, hash: msg_hash, addr_buffer, r3: 64) {
-        move pub_key_buffer sp; // pub_key result buffer.
+    // s256: The sha-256 hash of $rC bytes starting at $rB.
+    let address = asm(pub_key_buffer, sig_ptr: signature.hi, hash: msg_hash, addr_buffer, sixty_four: 64) {
+        move pub_key_buffer sp; // mv sp to pub_key result buffer.
         cfei i64;
         ecr pub_key_buffer sig_ptr hash; // recover public_key from sig & hash
-        move addr_buffer sp; // addr result buffer.
+        move addr_buffer sp; // mv sp to addr result buffer.
         cfei i32;
-        k256 addr_buffer pub_key_buffer r3; // hash 64 bytes to the addr_buffer
+        s256 addr_buffer pub_key_buffer sixty_four; // hash 64 bytes to the addr_buffer
         addr_buffer: b256
     };
 

--- a/src/ecr.sw
+++ b/src/ecr.sw
@@ -14,24 +14,15 @@ pub fn ec_recover(signature: B512, msg_hash: b256) -> B512 {
         ecr buffer hi hash;
         buffer: b256
     };
-    // @note temp
-    assert(public_key.hi == 0x1d152307c6b72b0ed0418b0e70cd80e7f5295b8d86f5722d3f5213fbd2394f36);
 
     // a `B512`'s 2 internal values are stored in contiguous memory. This asm block takes a pointer to the initial value (public_key.hi) and should retrieve the lo value from memory and return it to be stored in public_key.lo.
     public_key.lo = asm(buffer, hi_ptr: public_key.hi, lo_ptr) {
-        move hi_ptr sp;
-        cfei i64;
         move buffer sp;
         cfei i32;
         addi lo_ptr hi_ptr i32; // set lo_ptr equal to hi_ptr + 32 bytes
-        move lo_ptr sp;
-        cfei i32;
         mcpi buffer lo_ptr i32; // copy 32 bytes starting at lo_ptr into buffer
         buffer: b256
     };
-    // @note temp
-    assert(public_key.lo == 0xb7ce9c3e45905178455900b44abb308f3ef480481a4b2ee3f70aca157fde396a);
-
     public_key
 }
 

--- a/src/ecr.sw
+++ b/src/ecr.sw
@@ -2,34 +2,9 @@ library ecr;
 
 use ::b512::B512;
 use ::address::Address;
-use ::chain::assert;
-
-/// Recover the public key derived from the private key used to sign a message
-pub fn ec_recover(signature: B512, msg_hash: b256) -> B512 {
-    let public_key = ~B512::new();
-
-    let hi = asm(buffer, hi: signature.hi, hash: msg_hash) {
-        move buffer sp; // Result buffer.
-        cfei i32;
-        ecr buffer hi hash;
-        buffer: b256
-    };
-
-    // a `B512`'s 2 internal values are stored in contiguous memory. This asm block takes a pointer to the initial value (public_key.hi) and should retrieve the lo value from memory and return it to be stored in public_key.lo.
-    public_key.lo = asm(buffer, hi_ptr: public_key.hi, lo_ptr) {
-        move buffer sp;
-        cfei i32;
-        addi lo_ptr hi_ptr i32; // set lo_ptr equal to hi_ptr + 32 bytes
-        mcpi buffer lo_ptr i32; // copy 32 bytes starting at lo_ptr into buffer
-        buffer: b256
-    };
-    public_key.hi = hi;
-    public_key
-}
 
 /// Recover the address derived from the private key used to sign a message
 pub fn ec_recover_address(signature: B512, msg_hash: b256) -> Address {
-
     // ECR: "The 64-byte public key (x, y) recovered from 64-byte signature starting at $rB on 32-byte message hash starting at $rC"
     // s256: The sha-256 hash of $rC bytes starting at $rB.
     let address = asm(pub_key_buffer, sig_ptr: signature.hi, hash: msg_hash, addr_buffer, sixty_four: 64) {

--- a/src/ecr.sw
+++ b/src/ecr.sw
@@ -1,0 +1,32 @@
+library ecr;
+
+use ::b512::B512;
+use ::address::Address;
+
+// @todo expose both a recovered address && a recovered public key for consumption
+
+/// Recover the address derived from the private key used to sign a message
+pub fn ec_recover(signature: B512, msg_hash: b256) -> Address {
+
+    // we know that the B512 type's inner values are contiguous in memory.
+    // the ERC OpCode descriptions states:
+    // "The 64-byte public key (x, y) recovered from 64-byte signature starting at $rB on 32-byte message hash starting at $rC"
+    // Store the first 32 bytes of the public key in pub_key_initial_bytes:
+    // @todo optimize. roll these 2 asm blocks into 1 and remove local variables.
+    let pub_key_initial_bytes = asm(buffer, hi: signature.hi, hash: msg_hash) {
+        move buffer sp; // Result buffer.
+        cfei i32;
+        ecr buffer hi hash;
+        buffer: b256
+    };
+
+    // hash 64 bytes starting at `first` (start of 64-byte public key)
+    let address = asm(buffer, first: pub_key_initial_bytes , r3: 64) {
+        move buffer sp; // Result buffer.
+        cfei i32;
+        s256 buffer first r3; // hash 64 bytes to the buffer
+        buffer: b256
+    };
+
+    ~Address::from(address)
+}

--- a/src/lib.sw
+++ b/src/lib.sw
@@ -9,6 +9,6 @@ dep contract_id;
 dep context;
 dep address;
 dep block;
-dep ecr
+dep ecr;
 
 use core::*;

--- a/src/lib.sw
+++ b/src/lib.sw
@@ -9,7 +9,7 @@ dep contract_id;
 dep context;
 dep address;
 dep block;
-dep ecr;
 dep result;
+dep ecr;
 
 use core::*;

--- a/src/lib.sw
+++ b/src/lib.sw
@@ -9,5 +9,6 @@ dep contract_id;
 dep context;
 dep address;
 dep block;
+dep ecr
 
 use core::*;


### PR DESCRIPTION
Adds a function `ec_recover_address` to recover the Fuel address derived from the private key used to sign the message.