### PR TITLE
Adding the missing `ec_recover`functionality

### DIFF
--- a/src/ecr.sw
+++ b/src/ecr.sw
@@ -3,6 +3,29 @@ library ecr;
 use ::b512::B512;
 use ::address::Address;
 
+/// Recover the public key derived from the private key used to sign a message
+pub fn ec_recover(signature: B512, msg_hash: b256) -> B512 {
+    let public_key = ~B512::new();
+
+    let hi = asm(buffer, hi: signature.hi, hash: msg_hash) {
+        move buffer sp; // Result buffer.
+        cfei i64;
+        ecr buffer hi hash;
+        buffer: b256
+    };
+
+    public_key.lo = asm(buffer, hi_ptr: hi, lo_ptr) {
+        move buffer sp;
+        cfei i32;
+        addi lo_ptr hi_ptr i32; // set lo_ptr equal to hi_ptr + 32 bytes
+        mcpi buffer lo_ptr i32; // copy 32 bytes starting at lo_ptr into buffer
+        buffer: b256
+    };
+
+    public_key.hi = hi;
+    public_key
+}
+
 /// Recover the address derived from the private key used to sign a message
 pub fn ec_recover_address(signature: B512, msg_hash: b256) -> Address {
     let address = asm(pub_key_buffer, sig_ptr: signature.hi, hash: msg_hash, addr_buffer, sixty_four: 64) {

--- a/src/ecr.sw
+++ b/src/ecr.sw
@@ -1,0 +1,32 @@
+library ecr;
+
+use ::b512::B512;
+use ::address::Address;
+
+// @todo expose both a recovered address && a recovered public key for consumption
+
+/// Recover the address derived from the private key used to sign a message
+pub fn ec_recover(signature: B512, msg_hash: b256) -> Address {
+
+    // we know that the B512 type's inner values are contiguous in memory.
+    // the ERC OpCode descriptions states:
+    // "The 64-byte public key (x, y) recovered from 64-byte signature starting at $rB on 32-byte message hash starting at $rC"
+    // Store the first 32 bytes of the public key in pub_key_initial_bytes:
+    // @todo optimize. roll these 2 asm blocks into 1 and remove local variables.
+    let pub_key_initial_bytes = asm(buffer, hi: signature.hi, hash: msg_hash) {
+        move buffer sp; // Result buffer.
+        cfei i32;
+        ecr buffer hi hash;
+        buffer: b256
+    };
+
+    // hash 64 bytes starting at `first` (start of 64-byte public key)
+    let address = asm(buffer, first: pub_key_initial_bytes , r3: 64) {
+        move buffer sp; // Result buffer.
+        cfei i32;
+        s256 buffer first r3; // hash 64 bytes to the buffer
+        buffer: b256
+    };
+
+    ~Address::from(address)
+}


### PR DESCRIPTION
Formerly, only `ec_recover_address` was implemented.
This fixes that by adding an `ec_recover` function.

Tests can be found in the Sway repo here: https://github.com/FuelLabs/sway/pull/626