### PR TITLE
Implement the Eq trait for Address

### DIFF
--- a/Forc.toml
+++ b/Forc.toml
@@ -1,8 +1,8 @@
 [project]
 author = "Fuel Labs <contact@fuel.sh>"
+entry = "lib.sw"
 license = "Apache-2.0"
 name = "lib-std"
-entry = "lib.sw"
 
 
 [dependencies]

--- a/src/address.sw
+++ b/src/address.sw
@@ -8,10 +8,10 @@ pub struct Address {
 
 impl core::ops::Eq for Address {
     fn eq(self, other: Self) -> bool {
-      // this needs to use MEQ !
-        asm(r1: self, r2: other, r3) {
-            eq r3 r1 r2;
-            r3: bool
+      // An `Address` in Sway is 32 bytes
+        asm(r1: self, r2: other, result, bytes_to_compare: 32) {
+            meq result r1 r2 bytes_to_compare;
+            result: bool
         }
     }
 }

--- a/src/address.sw
+++ b/src/address.sw
@@ -27,7 +27,7 @@ impl core::ops::Ord for Address {
     }
 }
 
-// @todo make this generic when possible
+// TODO make this generic when possible.
 pub trait From {
     fn from(b: b256) -> Self;
 } {

--- a/src/address.sw
+++ b/src/address.sw
@@ -8,7 +8,7 @@ pub struct Address {
 
 impl core::ops::Eq for Address {
     fn eq(self, other: Self) -> bool {
-      // An `Address` in Sway is 32 bytes
+        // An `Address` in Sway is 32 bytes
         asm(r1: self, r2: other, result, bytes_to_compare: 32) {
             meq result r1 r2 bytes_to_compare;
             result: bool

--- a/src/address.sw
+++ b/src/address.sw
@@ -16,7 +16,6 @@ impl core::ops::Eq for Address {
     }
 }
 
-// TODO make this generic when possible.
 pub trait From {
     fn from(b: b256) -> Self;
 } {

--- a/src/address.sw
+++ b/src/address.sw
@@ -6,6 +6,27 @@ pub struct Address {
     value: b256,
 }
 
+impl core::ops::Ord for Address {
+    fn gt(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3) {
+            gt r3 r1 r2;
+            r3: bool
+        }
+    }
+    fn lt(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3) {
+            lt r3 r1 r2;
+            r3: bool
+        }
+    }
+    fn eq(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3) {
+            eq r3 r1 r2;
+            r3: bool
+        }
+    }
+}
+
 // @todo make this generic when possible
 pub trait From {
     fn from(b: b256) -> Self;

--- a/src/address.sw
+++ b/src/address.sw
@@ -6,20 +6,9 @@ pub struct Address {
     value: b256,
 }
 
-impl core::ops::Ord for Address {
-    fn gt(self, other: Self) -> bool {
-        asm(r1: self, r2: other, r3) {
-            gt r3 r1 r2;
-            r3: bool
-        }
-    }
-    fn lt(self, other: Self) -> bool {
-        asm(r1: self, r2: other, r3) {
-            lt r3 r1 r2;
-            r3: bool
-        }
-    }
+impl core::ops::Eq for Address {
     fn eq(self, other: Self) -> bool {
+      // this needs to use MEQ !
         asm(r1: self, r2: other, r3) {
             eq r3 r1 r2;
             r3: bool


### PR DESCRIPTION
Implements the `Eq` trait for `Address`using a wrapper around the `meq` opcode.

Test for this added here: https://github.com/FuelLabs/sway/pull/672
Blocked by https://github.com/FuelLabs/sway-lib-core/issues/8
