### PR TITLE
Adding the force_transfer function to the token lib.

### DIFF
--- a/src/token.sw
+++ b/src/token.sw
@@ -14,3 +14,12 @@ pub fn burn(amount: u64) {
         burn r1;
     }
 }
+
+/// !!! UNCONDITIONAL transfer of `amount` coins of type `asset_id` to contract at `contract_id`.
+/// This will allow the transfer of coins even if there is no way to retrieve them !!!
+/// Use of this function can lead to irretrievable loss of coins if not used with caution.
+pub fn force_transfer(amount: u64, asset_id: ContractId, contract_id: ContractId) {
+    asm(r1: amount, r2: asset_id.value, r3: contract_id.value) {
+        tr r3 r1 r2;
+    }
+}

--- a/src/token.sw
+++ b/src/token.sw
@@ -1,6 +1,8 @@
 library token;
 //! Functionality for performing common operations on tokens.
 
+use ::contract_id::ContractId;
+
 /// Mint `amount` coins of the current contract's `asset_id`.
 pub fn mint(amount: u64) {
     asm(r1: amount) {


### PR DESCRIPTION
- Adds a single function to allow the unconditional transfer of coins to a contract.

The tests can be found here: https://github.com/FuelLabs/sway/pull/697