### PR TITLE
Modify import syntax to use latest lib-core

### DIFF
--- a/Forc.toml
+++ b/Forc.toml
@@ -6,4 +6,4 @@ name = "lib-std"
 
 
 [dependencies]
-"core" = { git = "http://github.com/FuelLabs/sway-lib-core" }
+"core" = { git = "http://github.com/FuelLabs/sway-lib-core", version =" " }

--- a/Forc.toml
+++ b/Forc.toml
@@ -6,4 +6,4 @@ name = "lib-std"
 
 
 [dependencies]
-"core" = { git = "http://github.com/FuelLabs/sway-lib-core", version =" " }
+"core" = { git = "http://github.com/FuelLabs/sway-lib-core", version = " " }


### PR DESCRIPTION
This changes the import version syntax from
`"core" = { git = "http://github.com/FuelLabs/sway-lib-core"}`
to
`"core" = { git = "http://github.com/FuelLabs/sway-lib-core", version =" " }`

The former was not picking up the latest changes to `lib-core`, while the latter appears to work.

After running `forc update`, core was updated successfully: `core: 45c54ab -> 5ff3559`

However, the changes to the address module were not being picked up : 

```
❯ forc build
  Compiled library "core".
error
 --> sway-lib-std/src/address.sw:5:17
  |
0 | library address;
1 | //! A wrapper around the b256 type to help enhance type-safety.
2 |
3 | /// The Address type, a struct wrappper around the inner `value`.
...
7 |
8 | impl core::ops::Eq for Address {
  |                 ^^ Could not find symbol "Eq" in this scope.
  |
error
 --> sway-lib-std/src/address.sw:5:12
  |
0 | library address;
1 | //! A wrapper around the b256 type to help enhance type-safety.
2 |
3 | /// The Address type, a struct wrappper around the inner `value`.
...
7 |
8 | impl core::ops::Eq for Address {
  |            ^^^^^^^ Trait "Eq" cannot be found in the current scope.
  |
error
 --> sway-lib-std/src/ecr.sw:0:7
  |
...
3 | use ::address::Address;
  |       ^^^^^^^ Module "address" could not be found.
  |
  Aborting due to 3 errors.
Error: "Failed to compile lib-std"
```

After changing the import syntax in the manifest and running `forc build` again, the errors relating to the address module are gone.
