### PR TITLE
Implementing an initial version of a msg_sender function

### DIFF
--- a/src/chain/auth.sw
+++ b/src/chain/auth.sw
@@ -1,4 +1,5 @@
 library auth;
+//! Functionality for determining who is calling an ABI method
 
 // this can be a generic option when options land
 enum Caller {

--- a/src/lib.sw
+++ b/src/lib.sw
@@ -1,16 +1,16 @@
 library std;
 
+dep result;
 dep hash;
 dep storage;
 dep constants;
 dep b512;
-dep chain;
-dep contract_id;
-dep context;
 dep address;
+dep contract_id;
+dep chain;
+dep context;
 dep block;
 dep token;
-dep result;
 dep ecr;
 
 use core::*;


### PR DESCRIPTION
In order to simplify the review of the authorization module as much as possible, I'm breaking it down into a few smaller chunks where it seems logical to do so.

This is a fist pass at a msg_sender function.
- For now, it will just (temporarily) return the `Err` variant of `Result` if the caller's context is **External**.
- A follow-up PR will add some additional branching logic and a function call to determine if (in the case of an **External** calling context) the input-coin owners are all the same.