### PR TITLE
Add Option type & is_some/is_none methods

### DIFF
--- a/src/lib.sw
+++ b/src/lib.sw
@@ -8,6 +8,7 @@ dep chain;
 dep contract_id;
 dep context;
 dep address;
+dep option;
 dep block;
 dep token;
 dep result;

--- a/src/option.sw
+++ b/src/option.sw
@@ -1,0 +1,52 @@
+//! Error handling with the `Option` type.
+//!
+//! [`Option<T>`][`Option`] is the type used for returning and propagating
+//! errors. It is an enum with the variants, [`Some(T)`], representing
+//! the existence of a value, and [`None()`], representing
+//! the absence of a value.
+
+library option;
+
+/// `Option` is a type that represents either the existence of a value ([`Some`]) or a value's absence
+/// ([`None`]).
+pub enum Option<T> {
+    /// Contains the value
+    Some: T,
+
+    /// Signifies the absence of a value
+    None: (),
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Type implementation
+/////////////////////////////////////////////////////////////////////////////
+
+impl Option<T> {
+    /////////////////////////////////////////////////////////////////////////
+    // Querying the contained values
+    /////////////////////////////////////////////////////////////////////////
+
+    /// Returns `true` if the result is [`Some`].
+    fn is_some(self) -> bool {
+        match self {
+            Option::Some(T) => {
+                true
+            },
+            _ => {
+                false
+            },
+        }
+    }
+
+    /// Returns `true` if the result is [`None`].
+    fn is_none(self) -> bool {
+        match self {
+            Option::Some() => {
+                false
+            },
+            _ => {
+                true
+            },
+        }
+    }
+}

--- a/src/option.sw
+++ b/src/option.sw
@@ -1,9 +1,8 @@
 //! Error handling with the `Option` type.
 //!
-//! [`Option<T>`][`Option`] is the type used for returning and propagating
-//! errors. It is an enum with the variants, [`Some(T)`], representing
-//! the existence of a value, and [`None()`], representing
-//! the absence of a value.
+//! [`Option<T>`][`Option`] is the type used for representing the existence or absence of a value. It is an enum with the variants, [`Some(T)`], representing
+//! some value, and [`None()`], representing
+//! no value.
 
 library option;
 

--- a/src/option.sw
+++ b/src/option.sw
@@ -40,7 +40,7 @@ impl Option<T> {
     /// Returns `true` if the result is [`None`].
     fn is_none(self) -> bool {
         match self {
-            Option::Some() => {
+            Option::Some(T) => {
                 false
             },
             _ => {


### PR DESCRIPTION
This is basically cloned from Result and adapted to fit the `Option` use case.
Tests to follow here: WIP: Tests are implemented but failing due to:
```
Option::Some(T) => {
   |             ^^^^^^^^^^^^^^^ Unimplemented feature: ASM generation has not yet been implemented for this.
```
Adding the tests is  blocked by https://github.com/FuelLabs/sway/issues/579

Closes #24 