### PR TITLE
Adding the transfer_to_output function to token library

### DIFF
--- a/src/token.sw
+++ b/src/token.sw
@@ -83,9 +83,9 @@ pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address)
     if !output_found {
         // If no suitable output was found, revert.
         panic(0);
-    };
-
-    asm(amnt: amount, id: asset_id.value, recipient: recipient.value, output: index) {
-        tro recipient output amnt id;
+    } else {
+        asm(amnt: amount, id: asset_id.value, recipient: recipient.value, output: index) {
+            tro recipient output amnt id;
+        }
     }
 }

--- a/src/token.sw
+++ b/src/token.sw
@@ -84,8 +84,9 @@ pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address)
         // If no suitable output was found, revert.
         panic(0);
     } else {
+        // perform the transfer
         asm(amnt: amount, id: asset_id.value, recipient: recipient.value, output: index) {
             tro recipient output amnt id;
         };
-    };
+    }
 }

--- a/src/token.sw
+++ b/src/token.sw
@@ -50,16 +50,21 @@ pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address)
     // If an output of type `OutputVariable` is found, check if its `amount` is zero.
     // As one cannot transfer zero coins to an output without a panic, a variable output with a value of zero is by definition unused.
     while index < length {
-        let type = asm(n: index, offset, t) {
+        let output_start = asm(n: index, offset) {
             xos offset n; // get the offset to the nth output
+            offset: u64
+        }
+
+        let type = asm(offset: output_start, t) {
             lb t offset i0; // load the type of the output at 'offset' into t
             t: u8
         };
 
         // if an ouput is found of type `OutputVariable`:
         if type == OUTPUT_VARIABLE_TYPE {
-            let amount = asm(slot: index, a, amount_ptr, output, is_zero, bytes: 8) {
-                xos output slot;
+            let amount = asm(n: index, a, amount_ptr, output: output_start) {
+                // TODO: fix offset here to be 16 or 40 depending on feedback:
+                // https://github.com/FuelLabs/sway-lib-std/pull/32#issuecomment-1028159987
                 addi amount_ptr output i32;
                 lw a amount_ptr i0;
                 a: u64

--- a/src/token.sw
+++ b/src/token.sw
@@ -14,3 +14,12 @@ pub fn burn(amount: u64) {
         burn r1;
     }
 }
+
+/// !!! UNCONDITIONAL transfer of `amount` coins of type `asset_id` to contract at `contract_id`.
+/// This will allow the transfer of coins even if there is no way to retrieve them !!!
+/// Use of this function can lead to irretrievable loss of coins if not used with caution.
+pub fn force_transfer(amount: u64, asset_id: ContractId, contract_id: ContractId) {
+    asm(r1: amount, r2: asset_id.value, r3: contract_id.value) {
+        tr r3 r1 r2;
+    }
+}

--- a/src/token.sw
+++ b/src/token.sw
@@ -55,19 +55,18 @@ pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address)
             lb t offset i0; // load the type of the output at 'offset' into t
             t: u8
         };
-        let target_output_type_exists = type == OUTPUT_VARIABLE_TYPE;
 
         // if an ouput is found of type `OutputVariable`:
-        if target_output_type_exists {
+        if type == OUTPUT_VARIABLE_TYPE {
             let amount = asm(slot: index, a, amount_ptr, output, is_zero, bytes: 8) {
                 xos output slot;
                 addi amount_ptr output i32;
                 lw a amount_ptr i0;
                 a: u64
             };
-            let amount_is_zero = amount == 0;
+
             // && if the amount is zero:
-            if amount_is_zero {
+            if amount == 0 {
                 // then store the index of the output and record the fact that we found a suitable output.
                 outputIndex = index;
                 output_found = true;

--- a/src/token.sw
+++ b/src/token.sw
@@ -53,7 +53,7 @@ pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address)
         let output_start = asm(n: index, offset) {
             xos offset n; // get the offset to the nth output
             offset: u64
-        }
+        };
 
         let type = asm(offset: output_start, t) {
             lb t offset i0; // load the type of the output at 'offset' into t

--- a/src/token.sw
+++ b/src/token.sw
@@ -25,3 +25,63 @@ pub fn force_transfer(amount: u64, asset_id: ContractId, contract_id: ContractId
         tr r3 r1 r2;
     }
 }
+
+// note: if tx format changes, the magic number "48" must be changed !
+/// TransactionScript outputsCount has a 48 byte(6 words * 8 bytes) offset
+/// Transaction Script: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#transactionscript
+/// Output types: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#output
+const OUTPUT_LENGTH_LOCATION = 48;
+const OUTPUT_VARIABLE_TYPE = 4;
+
+/// Transfer `amount` coins of type `asset_id` to address `recipient`.
+pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address) {
+    // get length of outputs from TransactionScript outputsCount:
+    let length: u8 = asm(outputs_length, outputs_length_ptr: OUTPUT_LENGTH_LOCATION) {
+        lw outputs_length outputs_length_ptr i0;
+        outputs_length: u8
+    };
+    // maintain a manual index as we only have `while` loops in sway atm:
+    let mut index: u8 = 0u8;
+    let mut outputIndex = 0;
+    let mut output_found = false;
+
+    // If an output of type `OutputVariable` is found, check if its `amount` is zero.
+    // As one cannot transfer zero coins to an output without a panic, a variable output with a value of zero is by definition unused.
+    while index < length {
+        let target_output_type_exists = asm(slot: index, type, target: OUTPUT_VARIABLE_TYPE, bytes: 8, res) {
+            xos type slot;
+            meq res type target bytes;
+            res: bool
+        };
+        // if an ouput is found of type `OutputVariable`:
+        if target_output_type_exists {
+            let amount_is_zero = asm(slot: index, a, amount_ptr, output, is_zero, bytes: 8) {
+                xos output slot;
+                addi amount_ptr output i64;
+                lw a amount_ptr i0;
+                meq is_zero a zero bytes;
+                is_zero: bool
+            };
+            // && if the amount is zero:
+            if amount_is_zero {
+                // then store the index of the output and record the fact that we found a suitable output.
+                outputIndex = index;
+                output_found = true;
+                // todo: use "break" keyword when it lands ( tracked here: https://github.com/FuelLabs/sway/issues/587 )
+                index = length; // break early and use the output we found
+            } else {
+                // otherwise, increment the index and continue the loop.
+                index = index + 1;
+            }
+        }
+    }
+
+    if !output_found {
+        // If no suitable output was found, revert.
+        panic(0);
+    };
+
+    asm(amnt: amount, id: asset_id.value, recipient: recipient.value, output: index) {
+        tro recipient output amnt id;
+    }
+}

--- a/src/token.sw
+++ b/src/token.sw
@@ -34,7 +34,7 @@ pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address)
     // TransactionScript outputsCount has a 48 byte(6 words * 8 bytes) offset
     // Transaction Script: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#transactionscript
     // Output types: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#output
-    const OUTPUT_LENGTH_LOCATION = 48;
+    const OUTPUT_LENGTH_LOCATION = 56;
     const OUTPUT_VARIABLE_TYPE = 4;
 
     // get length of outputs from TransactionScript outputsCount:

--- a/src/token.sw
+++ b/src/token.sw
@@ -30,8 +30,8 @@ pub fn force_transfer(amount: u64, asset_id: ContractId, contract_id: ContractId
 
 /// Transfer `amount` coins of type `asset_id` to address `recipient`.
 pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address) {
-    // note: if tx format changes, the magic number "48" must be changed !
-    // TransactionScript outputsCount has a 48 byte(6 words * 8 bytes) offset
+    // note: if tx format changes, the magic number "56" must be changed !
+    // TransactionScript outputsCount has a 56 byte(7 words * 8 bytes) offset
     // Transaction Script: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#transactionscript
     // Output types: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#output
     const OUTPUT_LENGTH_LOCATION = 56;

--- a/src/token.sw
+++ b/src/token.sw
@@ -63,9 +63,7 @@ pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address)
         // if an ouput is found of type `OutputVariable`:
         if type == OUTPUT_VARIABLE_TYPE {
             let amount = asm(n: index, a, amount_ptr, output: output_start) {
-                // TODO: fix offset here to be 16 or 40 depending on feedback:
-                // https://github.com/FuelLabs/sway-lib-std/pull/32#issuecomment-1028159987
-                addi amount_ptr output i32;
+                addi amount_ptr output i40;
                 lw a amount_ptr i0;
                 a: u64
             };

--- a/src/token.sw
+++ b/src/token.sw
@@ -1,6 +1,8 @@
 library token;
 //! Functionality for performing common operations on tokens.
 
+use ::contract_id::ContractId;
+
 /// Mint `amount` coins of the current contract's `asset_id`.
 pub fn mint(amount: u64) {
     asm(r1: amount) {

--- a/src/token.sw
+++ b/src/token.sw
@@ -74,10 +74,10 @@ pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address)
             } else {
                 // otherwise, increment the index and continue the loop.
                 index = index + 1;
-            }
+            };
         } else {
-                index = length; // break early as there are no suitable outputs.
-            }
+            index = length; // break early as there are no suitable outputs.
+        };
     }
 
     if !output_found {
@@ -86,6 +86,6 @@ pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address)
     } else {
         asm(amnt: amount, id: asset_id.value, recipient: recipient.value, output: index) {
             tro recipient output amnt id;
-        }
-    }
+        };
+    };
 }

--- a/src/token.sw
+++ b/src/token.sw
@@ -29,9 +29,9 @@ pub fn force_transfer(amount: u64, asset_id: ContractId, contract_id: ContractId
 }
 
 // note: if tx format changes, the magic number "48" must be changed !
-/// TransactionScript outputsCount has a 48 byte(6 words * 8 bytes) offset
-/// Transaction Script: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#transactionscript
-/// Output types: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#output
+// TransactionScript outputsCount has a 48 byte(6 words * 8 bytes) offset
+// Transaction Script: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#transactionscript
+// Output types: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#output
 // const OUTPUT_LENGTH_LOCATION = 48;
 // const OUTPUT_VARIABLE_TYPE = 4;
 

--- a/src/token.sw
+++ b/src/token.sw
@@ -75,7 +75,9 @@ pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address)
                 // otherwise, increment the index and continue the loop.
                 index = index + 1;
             }
-        }
+        } else {
+                index = length; // break early
+            }
     }
 
     if !output_found {

--- a/src/token.sw
+++ b/src/token.sw
@@ -2,6 +2,8 @@ library token;
 //! Functionality for performing common operations on tokens.
 
 use ::contract_id::ContractId;
+use ::address::Address;
+use ::chain::panic;
 
 /// Mint `amount` coins of the current contract's `asset_id`.
 pub fn mint(amount: u64) {
@@ -30,13 +32,13 @@ pub fn force_transfer(amount: u64, asset_id: ContractId, contract_id: ContractId
 /// TransactionScript outputsCount has a 48 byte(6 words * 8 bytes) offset
 /// Transaction Script: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#transactionscript
 /// Output types: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#output
-const OUTPUT_LENGTH_LOCATION = 48;
-const OUTPUT_VARIABLE_TYPE = 4;
+// const OUTPUT_LENGTH_LOCATION = 48;
+// const OUTPUT_VARIABLE_TYPE = 4;
 
 /// Transfer `amount` coins of type `asset_id` to address `recipient`.
 pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address) {
     // get length of outputs from TransactionScript outputsCount:
-    let length: u8 = asm(outputs_length, outputs_length_ptr: OUTPUT_LENGTH_LOCATION) {
+    let length: u8 = asm(outputs_length, outputs_length_ptr: 48) {
         lw outputs_length outputs_length_ptr i0;
         outputs_length: u8
     };
@@ -48,7 +50,7 @@ pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address)
     // If an output of type `OutputVariable` is found, check if its `amount` is zero.
     // As one cannot transfer zero coins to an output without a panic, a variable output with a value of zero is by definition unused.
     while index < length {
-        let target_output_type_exists = asm(slot: index, type, target: OUTPUT_VARIABLE_TYPE, bytes: 8, res) {
+        let target_output_type_exists = asm(slot: index, type, target: 4, bytes: 8, res) {
             xos type slot;
             meq res type target bytes;
             res: bool

--- a/src/token.sw
+++ b/src/token.sw
@@ -76,7 +76,7 @@ pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address)
                 index = index + 1;
             }
         } else {
-                index = length; // break early
+                index = length; // break early as there are no suitable outputs.
             }
     }
 

--- a/src/token.sw
+++ b/src/token.sw
@@ -28,17 +28,17 @@ pub fn force_transfer(amount: u64, asset_id: ContractId, contract_id: ContractId
     }
 }
 
-// note: if tx format changes, the magic number "48" must be changed !
-// TransactionScript outputsCount has a 48 byte(6 words * 8 bytes) offset
-// Transaction Script: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#transactionscript
-// Output types: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#output
-// const OUTPUT_LENGTH_LOCATION = 48;
-// const OUTPUT_VARIABLE_TYPE = 4;
-
 /// Transfer `amount` coins of type `asset_id` to address `recipient`.
 pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address) {
+    // note: if tx format changes, the magic number "48" must be changed !
+    // TransactionScript outputsCount has a 48 byte(6 words * 8 bytes) offset
+    // Transaction Script: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#transactionscript
+    // Output types: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#output
+    const OUTPUT_LENGTH_LOCATION = 48;
+    const OUTPUT_VARIABLE_TYPE = 4;
+
     // get length of outputs from TransactionScript outputsCount:
-    let length: u8 = asm(outputs_length, outputs_length_ptr: 48) {
+    let length: u8 = asm(outputs_length, outputs_length_ptr: OUTPUT_LENGTH_LOCATION) {
         lw outputs_length outputs_length_ptr i0;
         outputs_length: u8
     };
@@ -50,7 +50,7 @@ pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address)
     // If an output of type `OutputVariable` is found, check if its `amount` is zero.
     // As one cannot transfer zero coins to an output without a panic, a variable output with a value of zero is by definition unused.
     while index < length {
-        let target_output_type_exists = asm(slot: index, type, target: 4, bytes: 8, res) {
+        let target_output_type_exists = asm(slot: index, type, target: OUTPUT_VARIABLE_TYPE, bytes: 8, res) {
             xos type slot;
             meq res type target bytes;
             res: bool


### PR DESCRIPTION
The 4th and final(for now) function for the token library.
>/// Transfer `amount` coins of type `asset_id` to address `recipient`.

The comments in the new function should provide a fairly clear explanation of what is going on.

Tests here: https://github.com/FuelLabs/sway/pull/722