### PR TITLE
Simplify the B512 (and therefore ECR) code.

### DIFF
--- a/src/b512.sw
+++ b/src/b512.sw
@@ -4,7 +4,8 @@ library b512;
 /// Stores two b256s in contiguous memory.
 /// Guaranteed to be contiguous for use with ec-recover: std::ecr::ec_recover().
 pub struct B512 {
-    bytes: [b256; 2],
+    bytes: [b256;
+    2],
 }
 
 // @todo use generic form when possible
@@ -19,7 +20,8 @@ pub trait From {
 impl From for B512 {
     fn from(h: b256, l: b256) -> B512 {
         B512 {
-            bytes: [h, l],
+            bytes: [h,
+            l], 
         }
     }
 }
@@ -30,7 +32,7 @@ impl B512 {
     fn new() -> B512 {
         B512 {
             bytes: [0x0000000000000000000000000000000000000000000000000000000000000000,
-                    0x0000000000000000000000000000000000000000000000000000000000000000],
+            0x0000000000000000000000000000000000000000000000000000000000000000], 
         }
     }
 }

--- a/src/b512.sw
+++ b/src/b512.sw
@@ -4,8 +4,7 @@ library b512;
 /// Stores two b256s in contiguous memory.
 /// Guaranteed to be contiguous for use with ec-recover: std::ecr::ec_recover().
 pub struct B512 {
-    hi: b256,
-    lo: b256,
+    bytes: [b256; 2],
 }
 
 // @todo use generic form when possible
@@ -16,32 +15,11 @@ pub trait From {
     // fn into() {...}
 }
 
-/// Functions for casting between B512 and b256 types.
+/// Functions for casting between B512 and raw byte arrays.
 impl From for B512 {
-    fn from(hi: b256, lo: b256) -> B512 {
-        // copy the two given b256s into contiguous stack memory
-        // this involves grabbing the stack pointer, extending the stack by 256 bits,
-        // using MCPI to copy hi into first ptr
-        // repeat w/ second ptr
-
-        let hi = asm(r1: hi, rhi) {
-            move rhi sp; // move stack pointer to rhi
-            cfei i32; // extend call frame by 32 bytes to allocate more memory. now $rhi is pointing to blank, uninitialized (but allocated) memory
-            mcpi rhi r1 i32;
-            rhi: b256
-        };
-
-        let lo = asm(r1: lo, rlo) {
-            move rlo sp;
-            cfei i32;
-            // now $rlo is pointing to blank memory that we can use
-            mcpi rlo r1 i32;
-            rlo: b256
-        };
-
+    fn from(h: b256, l: b256) -> B512 {
         B512 {
-            hi: hi,
-            lo: lo,
+            bytes: [h, l],
         }
     }
 }
@@ -50,21 +28,9 @@ impl From for B512 {
 impl B512 {
     /// Initializes a new, zeroed B512.
     fn new() -> B512 {
-        let hi = asm(rhi) {
-            move rhi sp;
-            cfei i32;
-            rhi: b256
-        };
-
-        let lo = asm(rlo) {
-            move rlo sp;
-            cfei i32;
-            rlo: b256
-        };
-
         B512 {
-            hi: hi,
-            lo: lo,
+            bytes: [0x0000000000000000000000000000000000000000000000000000000000000000,
+                    0x0000000000000000000000000000000000000000000000000000000000000000],
         }
     }
 }

--- a/src/ecr.sw
+++ b/src/ecr.sw
@@ -7,34 +7,23 @@ use ::address::Address;
 pub fn ec_recover(signature: B512, msg_hash: b256) -> B512 {
     let public_key = ~B512::new();
 
-    let hi = asm(buffer, hi: signature.hi, hash: msg_hash) {
-        move buffer sp; // Result buffer.
-        cfei i64;
-        ecr buffer hi hash;
-        buffer: b256
+    asm(buffer: public_key.bytes, sig: signature.bytes, hash: msg_hash) {
+        ecr buffer sig hash;
     };
 
-    public_key.lo = asm(buffer, hi_ptr: hi, lo_ptr) {
-        move buffer sp;
-        cfei i32;
-        addi lo_ptr hi_ptr i32; // set lo_ptr equal to hi_ptr + 32 bytes
-        mcpi buffer lo_ptr i32; // copy 32 bytes starting at lo_ptr into buffer
-        buffer: b256
-    };
-
-    public_key.hi = hi;
     public_key
 }
 
 /// Recover the address derived from the private key used to sign a message
 pub fn ec_recover_address(signature: B512, msg_hash: b256) -> Address {
-    let address = asm(pub_key_buffer, sig_ptr: signature.hi, hash: msg_hash, addr_buffer, sixty_four: 64) {
-        move pub_key_buffer sp; // mv sp to pub_key result buffer.
-        cfei i64;
-        ecr pub_key_buffer sig_ptr hash; // recover public_key from sig & hash
-        move addr_buffer sp; // mv sp to addr result buffer.
+    let address = asm(sig: signature.bytes, hash: msg_hash, addr_buffer, pub_key_buffer, hash_len: 64) {
+        move addr_buffer sp;                      // Buffer for address.
         cfei i32;
-        s256 addr_buffer pub_key_buffer sixty_four; // hash 64 bytes to the addr_buffer
+        move pub_key_buffer sp;                   // Temporary buffer for recovered key.
+        cfei i64;
+        ecr pub_key_buffer sig hash;              // Recover public_key from sig & hash.
+        s256 addr_buffer pub_key_buffer hash_len; // Hash 64 bytes to the addr_buffer.
+        cfsi i64;                                 // Free temporary key buffer.
         addr_buffer: b256
     };
 

--- a/src/ecr.sw
+++ b/src/ecr.sw
@@ -17,13 +17,13 @@ pub fn ec_recover(signature: B512, msg_hash: b256) -> B512 {
 /// Recover the address derived from the private key used to sign a message
 pub fn ec_recover_address(signature: B512, msg_hash: b256) -> Address {
     let address = asm(sig: signature.bytes, hash: msg_hash, addr_buffer, pub_key_buffer, hash_len: 64) {
-        move addr_buffer sp;                      // Buffer for address.
+        move addr_buffer sp; // Buffer for address.
         cfei i32;
-        move pub_key_buffer sp;                   // Temporary buffer for recovered key.
+        move pub_key_buffer sp; // Temporary buffer for recovered key.
         cfei i64;
-        ecr pub_key_buffer sig hash;              // Recover public_key from sig & hash.
+        ecr pub_key_buffer sig hash; // Recover public_key from sig & hash.
         s256 addr_buffer pub_key_buffer hash_len; // Hash 64 bytes to the addr_buffer.
-        cfsi i64;                                 // Free temporary key buffer.
+        cfsi i64; // Free temporary key buffer.
         addr_buffer: b256
     };
 


### PR DESCRIPTION
Instead of 2 b256 fields in a struct we can use a 2 element array instead.

I found that both the assumptions about memory layout and all the copying was producing brittle code, and simplifying the ASM blocks as much as possible is a good thing.