### PR TITLE
bugfix: remove second register from gm opcode

### DIFF
--- a/src/chain/auth.sw
+++ b/src/chain/auth.sw
@@ -15,6 +15,7 @@ pub enum Sender {
 }
 
 /// Returns `true` if the caller is external (ie: a script or predicate).
+// ref: https://github.com/FuelLabs/fuel-specs/blob/master/specs/vm/opcodes.md#gm-get-metadata
 pub fn caller_is_external() -> bool {
     asm(r1) {
         gm r1 i1;

--- a/src/chain/auth.sw
+++ b/src/chain/auth.sw
@@ -5,11 +5,6 @@ use ::result::Result;
 use ::address::Address;
 use ::contract_id::ContractId;
 
-// TODO: use an enum instead of loose contants for these once match statements work with enum.
-/// tracked here: https://github.com/FuelLabs/sway/issues/579
-const IS_CALLER_EXTERNAL = 1;
-const GET_CALLER = 2;
-
 pub enum AuthError {
     ContextError: (),
 }
@@ -21,8 +16,8 @@ pub enum Sender {
 
 /// Returns `true` if the caller is external (ie: a script or predicate).
 pub fn caller_is_external() -> bool {
-    asm(r1, r2: IS_CALLER_EXTERNAL) {
-        gm r1 r2;
+    asm(r1) {
+        gm r1 i1;
         r1: bool
     }
 }
@@ -36,8 +31,8 @@ pub fn msg_sender() -> Result<Sender, AuthError> {
         Result::Err(AuthError::ContextError)
     } else {
         // Get caller's contract ID
-        let id = ~ContractId::from(asm(r1, r2: GET_CALLER) {
-            gm r1 r2;
+        let id = ~ContractId::from(asm(r1) {
+            gm r1 i2;
             r1: b256
         });
         Result::Ok(Sender::Id(id))


### PR DESCRIPTION
The Auth module makes use of the `gm` opcode in 2 places.
we currently do this:
```
asm(r1, r2: IS_CALLER_EXTERNAL) {
        gm r1 r2;
        r1: bool
    }
```
Until now we haven't been able to properly test this, but today I found that what we have currently is wrong. The error is:
```
gm r1 r2;
  ^^^^^^^^^ This op expects 1 register(s) as arguments, but you provided 2 register(s).
```

This PR fixes that.