### PR TITLE
Use `t` instead of `T` for `Result` matches.

### DIFF
--- a/src/option.sw
+++ b/src/option.sw
@@ -28,7 +28,7 @@ impl Option<T> {
     /// Returns `true` if the result is [`Some`].
     fn is_some(self) -> bool {
         match self {
-            Option::Some(T) => {
+            Option::Some(t) => {
                 true
             },
             _ => {
@@ -40,7 +40,7 @@ impl Option<T> {
     /// Returns `true` if the result is [`None`].
     fn is_none(self) -> bool {
         match self {
-            Option::Some(T) => {
+            Option::Some(t) => {
                 false
             },
             _ => {

--- a/src/result.sw
+++ b/src/result.sw
@@ -29,7 +29,7 @@ impl Result<T, E> {
     /// Returns `true` if the result is [`Ok`].
     fn is_ok(self) -> bool {
         match self {
-            Result::Ok(T) => {
+            Result::Ok(t) => {
                 true
             },
             _ => {
@@ -41,7 +41,7 @@ impl Result<T, E> {
     /// Returns `true` if the result is [`Err`].
     fn is_err(self) -> bool {
         match self {
-            Result::Ok(T) => {
+            Result::Ok(t) => {
                 false
             },
             _ => {


### PR DESCRIPTION
`T` is a type name, so use `t` instead. Technically, `_` should be used, but that doesn't work yet, so at least this change should avoid errors popping up once inner values can be extracted from enums.