### PR TITLE
change author to authors in Forc.toml files

### DIFF
--- a/Forc.toml
+++ b/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "lib.sw"
 license = "Apache-2.0"
 name = "lib-std"

--- a/tests/Forc.toml
+++ b/tests/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "tests"

--- a/tests/test_artifacts/balance_contract/Forc.toml
+++ b/tests/test_artifacts/balance_contract/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "balance_contract"

--- a/tests/test_projects/token_ops/Forc.toml
+++ b/tests/test_projects/token_ops/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "token_ops"


### PR DESCRIPTION
Updating 'Forc.toml' files to use 'authors' instead of 'author'. This enables compatibility with the change being made in this PR https://github.com/FuelLabs/sway/pull/822