### PR TITLE
Avoid implicit cast warning

### DIFF
--- a/src/token.sw
+++ b/src/token.sw
@@ -44,7 +44,7 @@ pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address)
     };
     // maintain a manual index as we only have `while` loops in sway atm:
     let mut index: u8 = 0u8;
-    let mut outputIndex = 0;
+    let mut output_index = 0;
     let mut output_found = false;
 
     // If an output of type `OutputVariable` is found, check if its `amount` is zero.
@@ -71,7 +71,7 @@ pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address)
             // && if the amount is zero:
             if amount == 0 {
                 // then store the index of the output and record the fact that we found a suitable output.
-                outputIndex = index;
+                output_index = index;
                 output_found = true;
                 // todo: use "break" keyword when it lands ( tracked here: https://github.com/FuelLabs/sway/issues/587 )
                 index = length; // break early and use the output we found

--- a/src/token.sw
+++ b/src/token.sw
@@ -35,7 +35,7 @@ pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address)
     // Transaction Script: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#transactionscript
     // Output types: https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#output
     const OUTPUT_LENGTH_LOCATION = 56;
-    const OUTPUT_VARIABLE_TYPE = 4;
+    const OUTPUT_VARIABLE_TYPE = 4u8;
 
     // get length of outputs from TransactionScript outputsCount:
     let length: u8 = asm(outputs_length, outputs_length_ptr: OUTPUT_LENGTH_LOCATION) {


### PR DESCRIPTION
Gets rid of this warning:
```
64 |         if type == OUTPUT_VARIABLE_TYPE {
   |                    -------------------- This cast, from integer type of width sixty four to integer type of width eight, will lose precision.
```
Long term, I don't expect implicit casts to be a thing. We've started making some changes towards that and we will also need https://github.com/FuelLabs/sway/issues/878 at some point.

Also, one minor variable naming issue.