### PR TITLE
Make core branch explicit

### DIFF
--- a/Forc.toml
+++ b/Forc.toml
@@ -5,4 +5,4 @@ license = "Apache-2.0"
 name = "lib-std"
 
 [dependencies]
-"core" = { git = "http://github.com/FuelLabs/sway-lib-core", branch="master" }
+"core" = { git = "http://github.com/FuelLabs/sway-lib-core", branch = "master" }

--- a/Forc.toml
+++ b/Forc.toml
@@ -5,4 +5,4 @@ license = "Apache-2.0"
 name = "lib-std"
 
 [dependencies]
-"core" = { git = "http://github.com/FuelLabs/sway-lib-core" }
+"core" = { git = "http://github.com/FuelLabs/sway-lib-core", branch="master" }


### PR DESCRIPTION
Explicitly use `master` for the branch.