### PR TITLE
Correct inline docs for registers.sw

### DIFF
--- a/src/registers.sw
+++ b/src/registers.sw
@@ -1,4 +1,4 @@
-//! Functions to expose the 16 reserved FuelVM registers for ease of use.
+//! Functions to expose 14 of the reserved FuelVM registers for ease of use.
 //! Ref: https://github.com/FuelLabs/fuel-specs/blob/master/specs/vm/main.md#semantics
 library registers;
 


### PR DESCRIPTION
A tiny change to reflect the fact that there are no wrapper functions to access the `zero` or `one` registers in this module.