### PR TITLE
Fix some `path`s in the test project dependencies

### DIFF
--- a/tests/Forc.toml
+++ b/tests/Forc.toml
@@ -1,9 +1,0 @@
-[project]
-authors = ["Fuel Labs <contact@fuel.sh>"]
-entry = "main.sw"
-license = "Apache-2.0"
-name = "tests"
-
-[dependencies]
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
-std = { path = "../src" }

--- a/tests/test_artifacts/balance_contract/Forc.toml
+++ b/tests/test_artifacts/balance_contract/Forc.toml
@@ -6,4 +6,4 @@ name = "balance_contract"
 
 [dependencies]
 core = { git = "http://github.com/FuelLabs/sway-lib-core" }
-std = { path = "../../../src" }
+std = { path = "../../../" }

--- a/tests/test_projects/registers/Forc.toml
+++ b/tests/test_projects/registers/Forc.toml
@@ -6,4 +6,4 @@ name = "registers"
 
 [dependencies]
 core = { git = "http://github.com/FuelLabs/sway-lib-core" }
-std = { path = "../../../src" }
+std = { path = "../../../" }

--- a/tests/test_projects/token_ops/Forc.toml
+++ b/tests/test_projects/token_ops/Forc.toml
@@ -6,4 +6,4 @@ name = "token_ops"
 
 [dependencies]
 core = { git = "http://github.com/FuelLabs/sway-lib-core" }
-std = { path = "../../../src" }
+std = { path = "../../../" }


### PR DESCRIPTION
The `path`s of dependencies should point to the directory containing
the dependency's `Forc.toml` (not the `src`). This commit fixes the
`Forc.toml`s of the test projects to account for this.

There was also a spuriuos Forc.toml at `tests/Forc.toml` which has been
removed.

_https://github.com/FuelLabs/sway/issues/923 related_