### PR TITLE
Rename param in the ContractId::into() implementation

### DIFF
--- a/src/contract_id.sw
+++ b/src/contract_id.sw
@@ -6,7 +6,7 @@ pub struct ContractId {
     value: b256,
 }
 
-// @todo make this a generic trait. tracked here: https://github.com/FuelLabs/sway-lib-std/issues/58
+// TODO: make this a generic trait. tracked here: https://github.com/FuelLabs/sway-lib-std/issues/58
 pub trait From {
     fn from(b: b256) -> Self;
 } {

--- a/src/contract_id.sw
+++ b/src/contract_id.sw
@@ -6,7 +6,7 @@ pub struct ContractId {
     value: b256,
 }
 
-// @todo make this generic when possible
+// @todo make this a generic trait. tracked here: https://github.com/FuelLabs/sway-lib-std/issues/58
 pub trait From {
     fn from(b: b256) -> Self;
 } {

--- a/src/contract_id.sw
+++ b/src/contract_id.sw
@@ -10,8 +10,8 @@ pub struct ContractId {
 pub trait From {
     fn from(b: b256) -> Self;
 } {
-    fn into(addr: ContractId) -> b256 {
-        addr.value
+    fn into(id: ContractId) -> b256 {
+        id.value
     }
 }
 


### PR DESCRIPTION
The param is currently named `addr`, as the trait was copy-pasted from the Address::into trait.
this renames it to `id`.