### PR TITLE
Prefer `https` over `http` for forc git dependency URLs

### DIFF
--- a/Forc.toml
+++ b/Forc.toml
@@ -5,4 +5,4 @@ license = "Apache-2.0"
 name = "lib-std"
 
 [dependencies]
-"core" = { git = "http://github.com/FuelLabs/sway-lib-core", branch = "master" }
+core = { git = "https://github.com/FuelLabs/sway-lib-core", branch = "master" }

--- a/tests/test_artifacts/balance_contract/Forc.toml
+++ b/tests/test_artifacts/balance_contract/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "balance_contract"
 
 [dependencies]
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+core = { git = "https://github.com/FuelLabs/sway-lib-core", branch = "master" }
 std = { path = "../../../" }

--- a/tests/test_projects/registers/Forc.toml
+++ b/tests/test_projects/registers/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "registers"
 
 [dependencies]
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+core = { git = "https://github.com/FuelLabs/sway-lib-core", branch = "master" }
 std = { path = "../../../" }

--- a/tests/test_projects/token_ops/Forc.toml
+++ b/tests/test_projects/token_ops/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "token_ops"
 
 [dependencies]
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+core = { git = "https://github.com/FuelLabs/sway-lib-core", branch = "master" }
 std = { path = "../../../" }


### PR DESCRIPTION
This helps to resolve some dependency double-ups pending a proper solution in `forc`.

See https://github.com/FuelLabs/sway/issues/931 and https://github.com/FuelLabs/fuels-rs/pull/150#discussion_r825312119