### PR TITLE
Change `[project]` name from `lib-std` to `std`

### DIFF
--- a/Forc.toml
+++ b/Forc.toml
@@ -2,7 +2,7 @@
 authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "lib.sw"
 license = "Apache-2.0"
-name = "lib-std"
+name = "std"
 
 [dependencies]
 core = { git = "https://github.com/FuelLabs/sway-lib-core", branch = "master" }


### PR DESCRIPTION
This will remove the need for specifying a `package` field for declarations of `std` under `[dependencies]` once https://github.com/FuelLabs/sway/issues/977 is implemented.