### PR TITLE
Cleanup stdlib tests

### DIFF
--- a/tests/test_projects/contract_id_type/mod.rs
+++ b/tests/test_projects/contract_id_type/mod.rs
@@ -7,7 +7,7 @@ use std::fs::read;
 
 #[tokio::test]
 async fn contract_id_eq_implementation() {
-    let bin = std::fs::read("test_projects/contract_id_type/out/debug/contract_id_type.bin");
+    let bin = read("test_projects/contract_id_type/out/debug/contract_id_type.bin");
     let client = Provider::launch(Config::local_node()).await.unwrap();
 
     let tx = Transaction::Script {

--- a/tests/test_projects/registers/mod.rs
+++ b/tests/test_projects/registers/mod.rs
@@ -1,4 +1,3 @@
-use fuel_core::service::{Config, FuelService};
 use fuel_tx::Salt;
 use fuel_vm::consts::VM_MAX_RAM;
 use fuels_abigen_macro::abigen;
@@ -13,26 +12,25 @@ abigen!(
 
 
 // Compile contract, create node and deploy contract, returning TestRegistersContract contract instance
-// TO DO : 
+// TO DO :
 //    -  Ability to return any type of Contract.
 //    -  Return a result
-async fn deploy_testRegisters_instance() -> TestRegistersContract {
+async fn deploy_test_registers_instance() -> TestRegistersContract {
 
     let salt = Salt::from([0u8; 32]);
     let compiled =
         Contract::load_sway_contract("test_projects/registers/out/debug/registers.bin", salt)
             .unwrap();
-    let server = FuelService::new_node(Config::local_node()).await.unwrap();
     let (provider, wallet) = test_helpers::setup_test_provider_and_wallet().await;
     let id = Contract::deploy(&compiled, &provider, &wallet, TxParameters::default()).await.unwrap();
-    
+
     TestRegistersContract::new(id.to_string(), provider, wallet)
 }
 
 #[tokio::test]
 async fn can_get_overflow() {
 
-    let instance = deploy_testRegisters_instance().await;
+    let instance = deploy_test_registers_instance().await;
     let result = instance.get_overflow().call().await.unwrap();
     assert_eq!(result.value, 0);
 }
@@ -40,23 +38,23 @@ async fn can_get_overflow() {
 #[tokio::test]
 async fn can_get_program_counter() {
 
-    let instance = deploy_testRegisters_instance().await;
+    let instance = deploy_test_registers_instance().await;
     let result = instance.get_program_counter().call().await.unwrap();
     assert!(is_within_range(result.value));
 }
 
 #[tokio::test]
 async fn can_get_stack_start_ptr() {
-    
-    let instance = deploy_testRegisters_instance().await;
+
+    let instance = deploy_test_registers_instance().await;
     let result = instance.get_stack_start_ptr().call().await.unwrap();
     assert!(is_within_range(result.value));
 }
 
 #[tokio::test]
 async fn can_get_stack_ptr() {
-    
-    let instance = deploy_testRegisters_instance().await;
+
+    let instance = deploy_test_registers_instance().await;
     let result = instance.get_stack_ptr().call().await.unwrap();
     assert!(is_within_range(result.value));
 }
@@ -64,7 +62,7 @@ async fn can_get_stack_ptr() {
 #[tokio::test]
 async fn can_get_frame_ptr() {
 
-    let instance = deploy_testRegisters_instance().await;
+    let instance = deploy_test_registers_instance().await;
     let result = instance.get_frame_ptr().call().await.unwrap();
     assert!(is_within_range(result.value));
 }
@@ -72,7 +70,7 @@ async fn can_get_frame_ptr() {
 #[tokio::test]
 async fn can_get_heap_ptr() {
 
-    let instance = deploy_testRegisters_instance().await;
+    let instance = deploy_test_registers_instance().await;
     let result = instance.get_heap_ptr().call().await.unwrap();
     assert!(is_within_range(result.value));
 }
@@ -80,7 +78,7 @@ async fn can_get_heap_ptr() {
 #[tokio::test]
 async fn can_get_error() {
 
-    let instance = deploy_testRegisters_instance().await;
+    let instance = deploy_test_registers_instance().await;
     let result = instance.get_error().call().await.unwrap();
     assert_eq!(result.value, 0);
 }
@@ -88,7 +86,7 @@ async fn can_get_error() {
 #[tokio::test]
 async fn can_get_global_gas() {
 
-    let instance = deploy_testRegisters_instance().await;
+    let instance = deploy_test_registers_instance().await;
     let result = instance.get_global_gas().call().await.unwrap();
     assert!(is_within_range(result.value));
 }
@@ -96,7 +94,7 @@ async fn can_get_global_gas() {
 #[tokio::test]
 async fn can_get_context_gas() {
 
-    let instance = deploy_testRegisters_instance().await;
+    let instance = deploy_test_registers_instance().await;
     let result = instance.get_context_gas().call().await.unwrap();
     assert!(is_within_range(result.value));
 }
@@ -104,7 +102,7 @@ async fn can_get_context_gas() {
 #[tokio::test]
 async fn can_get_balance() {
 
-    let instance = deploy_testRegisters_instance().await;
+    let instance = deploy_test_registers_instance().await;
     let result = instance.get_balance().call().await.unwrap();
     assert_eq!(result.value, 0);
 }
@@ -112,7 +110,7 @@ async fn can_get_balance() {
 #[tokio::test]
 async fn can_get_instrs_start() {
 
-    let instance = deploy_testRegisters_instance().await;
+    let instance = deploy_test_registers_instance().await;
     let result = instance.get_instrs_start().call().await.unwrap();
     assert!(is_within_range(result.value));
 }
@@ -120,7 +118,7 @@ async fn can_get_instrs_start() {
 #[tokio::test]
 async fn can_get_return_value() {
 
-    let instance = deploy_testRegisters_instance().await;
+    let instance = deploy_test_registers_instance().await;
     let result = instance.get_return_value().call().await.unwrap();
     assert_eq!(result.value, 0);
 }
@@ -128,7 +126,7 @@ async fn can_get_return_value() {
 #[tokio::test]
 async fn can_get_return_length() {
 
-    let instance = deploy_testRegisters_instance().await;
+    let instance = deploy_test_registers_instance().await;
     let result = instance.get_return_length().call().await.unwrap();
     assert_eq!(result.value, 0);
 }
@@ -136,7 +134,7 @@ async fn can_get_return_length() {
 #[tokio::test]
 async fn can_get_flags() {
 
-    let instance = deploy_testRegisters_instance().await;
+    let instance = deploy_test_registers_instance().await;
     let result = instance.get_flags().call().await.unwrap();
     assert_eq!(result.value, 0);
 }

--- a/tests/test_projects/registers/mod.rs
+++ b/tests/test_projects/registers/mod.rs
@@ -1,35 +1,33 @@
 use fuel_tx::Salt;
 use fuel_vm::consts::VM_MAX_RAM;
 use fuels_abigen_macro::abigen;
-use fuels_contract::{parameters::TxParameters, contract::Contract};
+use fuels_contract::{contract::Contract, parameters::TxParameters};
 use fuels_signers::util::test_helpers;
-
 
 abigen!(
     TestRegistersContract,
     "test_projects/registers/out/debug/registers-abi.json",
 );
 
-
 // Compile contract, create node and deploy contract, returning TestRegistersContract contract instance
 // TO DO :
 //    -  Ability to return any type of Contract.
 //    -  Return a result
 async fn deploy_test_registers_instance() -> TestRegistersContract {
-
     let salt = Salt::from([0u8; 32]);
     let compiled =
         Contract::load_sway_contract("test_projects/registers/out/debug/registers.bin", salt)
             .unwrap();
     let (provider, wallet) = test_helpers::setup_test_provider_and_wallet().await;
-    let id = Contract::deploy(&compiled, &provider, &wallet, TxParameters::default()).await.unwrap();
+    let id = Contract::deploy(&compiled, &provider, &wallet, TxParameters::default())
+        .await
+        .unwrap();
 
     TestRegistersContract::new(id.to_string(), provider, wallet)
 }
 
 #[tokio::test]
 async fn can_get_overflow() {
-
     let instance = deploy_test_registers_instance().await;
     let result = instance.get_overflow().call().await.unwrap();
     assert_eq!(result.value, 0);
@@ -37,7 +35,6 @@ async fn can_get_overflow() {
 
 #[tokio::test]
 async fn can_get_program_counter() {
-
     let instance = deploy_test_registers_instance().await;
     let result = instance.get_program_counter().call().await.unwrap();
     assert!(is_within_range(result.value));
@@ -45,7 +42,6 @@ async fn can_get_program_counter() {
 
 #[tokio::test]
 async fn can_get_stack_start_ptr() {
-
     let instance = deploy_test_registers_instance().await;
     let result = instance.get_stack_start_ptr().call().await.unwrap();
     assert!(is_within_range(result.value));
@@ -53,7 +49,6 @@ async fn can_get_stack_start_ptr() {
 
 #[tokio::test]
 async fn can_get_stack_ptr() {
-
     let instance = deploy_test_registers_instance().await;
     let result = instance.get_stack_ptr().call().await.unwrap();
     assert!(is_within_range(result.value));
@@ -61,7 +56,6 @@ async fn can_get_stack_ptr() {
 
 #[tokio::test]
 async fn can_get_frame_ptr() {
-
     let instance = deploy_test_registers_instance().await;
     let result = instance.get_frame_ptr().call().await.unwrap();
     assert!(is_within_range(result.value));
@@ -69,7 +63,6 @@ async fn can_get_frame_ptr() {
 
 #[tokio::test]
 async fn can_get_heap_ptr() {
-
     let instance = deploy_test_registers_instance().await;
     let result = instance.get_heap_ptr().call().await.unwrap();
     assert!(is_within_range(result.value));
@@ -77,7 +70,6 @@ async fn can_get_heap_ptr() {
 
 #[tokio::test]
 async fn can_get_error() {
-
     let instance = deploy_test_registers_instance().await;
     let result = instance.get_error().call().await.unwrap();
     assert_eq!(result.value, 0);
@@ -85,7 +77,6 @@ async fn can_get_error() {
 
 #[tokio::test]
 async fn can_get_global_gas() {
-
     let instance = deploy_test_registers_instance().await;
     let result = instance.get_global_gas().call().await.unwrap();
     assert!(is_within_range(result.value));
@@ -93,7 +84,6 @@ async fn can_get_global_gas() {
 
 #[tokio::test]
 async fn can_get_context_gas() {
-
     let instance = deploy_test_registers_instance().await;
     let result = instance.get_context_gas().call().await.unwrap();
     assert!(is_within_range(result.value));
@@ -101,7 +91,6 @@ async fn can_get_context_gas() {
 
 #[tokio::test]
 async fn can_get_balance() {
-
     let instance = deploy_test_registers_instance().await;
     let result = instance.get_balance().call().await.unwrap();
     assert_eq!(result.value, 0);
@@ -109,7 +98,6 @@ async fn can_get_balance() {
 
 #[tokio::test]
 async fn can_get_instrs_start() {
-
     let instance = deploy_test_registers_instance().await;
     let result = instance.get_instrs_start().call().await.unwrap();
     assert!(is_within_range(result.value));
@@ -117,7 +105,6 @@ async fn can_get_instrs_start() {
 
 #[tokio::test]
 async fn can_get_return_value() {
-
     let instance = deploy_test_registers_instance().await;
     let result = instance.get_return_value().call().await.unwrap();
     assert_eq!(result.value, 0);
@@ -125,7 +112,6 @@ async fn can_get_return_value() {
 
 #[tokio::test]
 async fn can_get_return_length() {
-
     let instance = deploy_test_registers_instance().await;
     let result = instance.get_return_length().call().await.unwrap();
     assert_eq!(result.value, 0);
@@ -133,7 +119,6 @@ async fn can_get_return_length() {
 
 #[tokio::test]
 async fn can_get_flags() {
-
     let instance = deploy_test_registers_instance().await;
     let result = instance.get_flags().call().await.unwrap();
     assert_eq!(result.value, 0);

--- a/tests/test_projects/token_ops/mod.rs
+++ b/tests/test_projects/token_ops/mod.rs
@@ -1,4 +1,3 @@
-use fuel_core::service::{Config, FuelService};
 use fuel_tx::Salt;
 use fuels_abigen_macro::abigen;
 use fuels_contract::{parameters::TxParameters, contract::Contract};
@@ -17,10 +16,9 @@ async fn mint() {
         Contract::load_sway_contract("test_projects/token_ops/out/debug/token_ops.bin", salt)
             .unwrap();
 
-    let server = FuelService::new_node(Config::local_node()).await.unwrap();
     let (provider, wallet) = test_helpers::setup_test_provider_and_wallet().await;
     let id = Contract::deploy(&compiled, &provider, &wallet, TxParameters::default()).await.unwrap();
-    
+
     let instance = TestFuelCoinContract::new(id.to_string(), provider, wallet);
 
     let target = testfuelcoincontract_mod::ContractId { value: id.into() };
@@ -45,11 +43,10 @@ async fn burn() {
     let compiled =
         Contract::load_sway_contract("test_projects/token_ops/out/debug/token_ops.bin", salt)
             .unwrap();
-            
-    let server = FuelService::new_node(Config::local_node()).await.unwrap();
+
     let (provider, wallet) = test_helpers::setup_test_provider_and_wallet().await;
     let id = Contract::deploy(&compiled, &provider, &wallet, TxParameters::default()).await.unwrap();
-    
+
     let instance = TestFuelCoinContract::new(id.to_string(), provider, wallet);
 
     let target = testfuelcoincontract_mod::ContractId { value: id.into() };

--- a/tests/test_projects/token_ops/mod.rs
+++ b/tests/test_projects/token_ops/mod.rs
@@ -1,8 +1,7 @@
 use fuel_tx::Salt;
 use fuels_abigen_macro::abigen;
-use fuels_contract::{parameters::TxParameters, contract::Contract};
+use fuels_contract::{contract::Contract, parameters::TxParameters};
 use fuels_signers::util::test_helpers;
-
 
 abigen!(
     TestFuelCoinContract,
@@ -17,7 +16,9 @@ async fn mint() {
             .unwrap();
 
     let (provider, wallet) = test_helpers::setup_test_provider_and_wallet().await;
-    let id = Contract::deploy(&compiled, &provider, &wallet, TxParameters::default()).await.unwrap();
+    let id = Contract::deploy(&compiled, &provider, &wallet, TxParameters::default())
+        .await
+        .unwrap();
 
     let instance = TestFuelCoinContract::new(id.to_string(), provider, wallet);
 
@@ -45,7 +46,9 @@ async fn burn() {
             .unwrap();
 
     let (provider, wallet) = test_helpers::setup_test_provider_and_wallet().await;
-    let id = Contract::deploy(&compiled, &provider, &wallet, TxParameters::default()).await.unwrap();
+    let id = Contract::deploy(&compiled, &provider, &wallet, TxParameters::default())
+        .await
+        .unwrap();
 
     let instance = TestFuelCoinContract::new(id.to_string(), provider, wallet);
 


### PR DESCRIPTION
This just:
- deals with compiler warnings
- applies `cargo fmt`

This will simplify review of another PR of mine with some of these changes in it as well.