### PR TITLE
Disable default features from fuel-core

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,7 +6,7 @@ name = "tests"
 version = "0.0.0"
 
 [dependencies]
-fuel-core = "0.4"
+fuel-core = { version = "0.4", default-features = false }
 fuel-gql-client = { version = "0.4", default-features = false }
 fuel-tx = "0.6"
 fuel-types = "0.3"


### PR DESCRIPTION
Default features were enabled for fuel-core causing rocksdb to be enabled and compiled. This was causing ulimit issues for some developers when running tests concurrently. This should also speed up build times a lot.