### PR TITLE
Add `Result.unwrap()`

### DIFF
--- a/src/chain.sw
+++ b/src/chain.sw
@@ -1,6 +1,8 @@
 library chain;
 dep chain/auth;
 
+use ::panic::panic;
+
 // When generics land, these will be generic.
 pub fn log_u64(val: u64) {
     asm(r1: val) {
@@ -23,15 +25,6 @@ pub fn log_u16(val: u16) {
 pub fn log_u8(val: u8) {
     asm(r1: val) {
         log r1 zero zero zero;
-    }
-}
-
-/// Context-dependent:
-/// will panic if used in a predicate
-/// will revert if used in a contract
-pub fn panic(code: u64) {
-    asm(r1: code) {
-        rvrt r1;
     }
 }
 

--- a/src/lib.sw
+++ b/src/lib.sw
@@ -1,5 +1,6 @@
 library std;
 
+dep panic;
 dep option;
 dep result;
 dep constants;

--- a/src/panic.sw
+++ b/src/panic.sw
@@ -1,0 +1,10 @@
+library panic;
+
+/// Context-dependent:
+/// will panic if used in a predicate
+/// will revert if used in a contract
+pub fn panic(code: u64) {
+    asm(r1: code) {
+        rvrt r1;
+    }
+}

--- a/src/result.sw
+++ b/src/result.sw
@@ -7,6 +7,8 @@
 
 library result;
 
+use ::panic::panic;
+
 /// `Result` is a type that represents either success ([`Ok`]) or failure
 /// ([`Err`]).
 pub enum Result<T, E> {
@@ -41,6 +43,19 @@ impl<T, E> Result<T, E> {
             false
         } else {
             true
+        }
+    }
+
+    /// Returns the contained [`Ok`] value, consuming the `self` value.
+    ///
+    /// Because this function may panic, its use is generally discouraged.
+    /// Instead, prefer to use pattern matching and handle the [`Err`]
+    /// case explicitly.
+    fn unwrap(self) -> T {
+        if let Result::Ok(inner_value) = self {
+            inner_value
+        } else {
+            panic(0);
         }
     }
 }

--- a/src/token.sw
+++ b/src/token.sw
@@ -3,7 +3,7 @@ library token;
 
 use ::contract_id::ContractId;
 use ::address::Address;
-use ::chain::panic;
+use ::panic::panic;
 
 /// Mint `amount` coins of the current contract's `asset_id`.
 pub fn mint(amount: u64) {

--- a/tests/test_projects/option/src/main.sw
+++ b/tests/test_projects/option/src/main.sw
@@ -1,6 +1,6 @@
 script;
 
-use std::chain::panic;
+use std::panic::panic;
 use std::option::*;
 
 fn main() {

--- a/tests/test_projects/result/src/main.sw
+++ b/tests/test_projects/result/src/main.sw
@@ -1,6 +1,6 @@
 script;
 
-use std::chain::panic;
+use std::panic::panic;
 use std::result::*;
 
 fn main() {

--- a/tests/test_projects/result/src/main.sw
+++ b/tests/test_projects/result/src/main.sw
@@ -6,6 +6,7 @@ use std::result::*;
 fn main() {
     test_ok();
     test_err();
+    test_unwrap_ok();
 }
 
 fn test_ok() {
@@ -20,6 +21,15 @@ fn test_err() {
     let r = Result::Err::<(), ()>(());
 
     if (r.is_ok() || !r.is_err()) {
+        panic(0);
+    }
+}
+
+fn test_unwrap_ok() {
+    let r = Result::Ok::<u64, ()>(42);
+
+    let u = r.unwrap();
+    if (u != 42) {
         panic(0);
     }
 }


### PR DESCRIPTION
Implement `Result.unwrap()`.

I refactored `panic` into its own library, since otherwise `chain::auth` depends on `result`, which depends on `chain::panic`, which would be a circular dependency.